### PR TITLE
bump dependency to Ruby 3.4 default shipped version `v3.2.0`

### DIFF
--- a/jektex.gemspec
+++ b/jektex.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7.0"
   spec.add_dependency "execjs", "~> 2.1", ">= 2.9.1"
-  spec.add_dependency "digest", "~> 3.1.1", ">= 3.1.1"
+  spec.add_dependency "digest", "~> 3.2.0", ">= 3.1.1"
   spec.add_dependency "htmlentities", "~> 4.3", ">= 4.3.4"
   spec.add_development_dependency "bundler", "~> 2.0", ">= 2.0.0"
 


### PR DESCRIPTION
Fixes: https://github.com/yagarea/jektex/issues/11